### PR TITLE
chore(vscode): pack files only necessary

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,3 +11,6 @@ vsc-extension-quickstart.md
 **/.eslintrc.json
 **/*.map
 **/*.ts
+.github
+.idea
+**/.prettierignore


### PR DESCRIPTION
fixes #6 
```
> webpack --mode production --devtool hidden-source-map

    [webpack-cli] Compiler starting...
    [webpack-cli] Compiler is using config: '/workspace/webpack.config.js'
    [webpack-cli] Compiler finished
asset extension.js 607 bytes [compared for emit] [minimized] (name: main) 1 related asset
./src/extension.ts 1.4 KiB [built] [code generated]
external "vscode" 42 bytes [built] [code generated]
webpack 5.65.0 compiled successfully in 1424 ms
CHANGELOG.md
dist/extension.js
package.json
README.md
 INFO
The latest version of vsce is 2.6.1 and you have 0.0.0.
Update it now: npm install -g vsce
```